### PR TITLE
Dispose process and read outputs before waiting

### DIFF
--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -67,11 +67,15 @@ namespace ResguardoApp
                 RedirectStandardOutput = true
             };
 
-            var process = Process.Start(processInfo);
-            process.WaitForExit();
+            using var process = Process.Start(processInfo);
+            if (process == null)
+            {
+                throw new InvalidOperationException("Failed to start process.");
+            }
 
             string output = process.StandardOutput.ReadToEnd();
             string error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
 
             if (process.ExitCode != 0)
             {


### PR DESCRIPTION
## Summary
- ensure ExecuteCommand uses `using` so the child process is disposed
- read process output and error before awaiting process exit

## Testing
- `dotnet test ResguardoApp/ResguardoApp.sln -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68940174e4bc832988a5080dba3199e5