### PR TITLE
Filter removable drives and handle empty labels

### DIFF
--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -190,12 +190,15 @@ private void SaveConfiguration()
             portableDisksListBox.Items.Clear();
             try
             {
-                var drives = DriveInfo.GetDrives();
-                                      //.Where(d => d.IsReady);
+                var drives = DriveInfo.GetDrives()
+                    .Where(d => d.DriveType == DriveType.Removable && d.IsReady);
 
                 foreach (var drive in drives)
                 {
-                    portableDisksListBox.Items.Add($"{drive.Name} ({drive.VolumeLabel})");
+                    var label = string.IsNullOrWhiteSpace(drive.VolumeLabel)
+                        ? "Sin etiqueta"
+                        : drive.VolumeLabel;
+                    portableDisksListBox.Items.Add($"{drive.Name} ({label})");
                 }
 
                 if (!portableDisksListBox.Items.Cast<string>().Any())


### PR DESCRIPTION
## Summary
- Only list removable and ready drives
- Avoid empty volume labels by showing "Sin etiqueta"

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`
- `dotnet build ResguardoApp/ResguardoApp.sln -p:EnableWindowsTargeting=true` *(fails: 'Program' already defines a member and missing override in ResguardoAppService)*

------
https://chatgpt.com/codex/tasks/task_e_68940177732c8329b1939d8d298b8725