### PR TITLE
Ensure timer is disposed on service stop

### DIFF
--- a/ResguardoApp/ResguardoService.cs
+++ b/ResguardoApp/ResguardoService.cs
@@ -22,15 +22,22 @@ namespace ResguardoApp
         protected override void OnStart(string[] args)
         {
             LoadConfiguration();
-            _timer = new System.Timers.Timer();
+
+            if (_timer == null)
+            {
+                _timer = new System.Timers.Timer();
+                _timer.Elapsed += new ElapsedEventHandler(OnTimer);
+            }
+
             _timer.Interval = 60000; // 1 minute
-            _timer.Elapsed += new ElapsedEventHandler(OnTimer);
             _timer.Start();
         }
 
         protected override void OnStop()
         {
-            _timer.Stop();
+            _timer?.Stop();
+            _timer?.Dispose();
+            _timer = null;
         }
 
         private void OnTimer(object sender, ElapsedEventArgs args)


### PR DESCRIPTION
## Summary
- Recreate service timer on start when missing
- Properly stop and dispose timer on service stop

## Testing
- `dotnet build ResguardoApp/ResguardoApp.sln -p:EnableWindowsTargeting=true` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_689401797c68832985fa9f09bd73ee6b