### PR TITLE
Refactor service class and entry point

### DIFF
--- a/ResguardoAppService/Program.cs
+++ b/ResguardoAppService/Program.cs
@@ -1,25 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ServiceProcess;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ResguardoAppService
 {
     internal static class Program
     {
         /// <summary>
-        /// The main entry point for the application.
+        /// Entry point for the service application.
         /// </summary>
         static void Main()
         {
-            ServiceBase[] ServicesToRun;
-            ServicesToRun = new ServiceBase[]
-            {
-                new Service1()
-            };
-            ServiceBase.Run(ServicesToRun);
+            ServiceBase.Run(new Service1());
         }
     }
 }
+

--- a/ResguardoAppService/Service1.Designer.cs
+++ b/ResguardoAppService/Service1.Designer.cs
@@ -1,8 +1,8 @@
-﻿namespace ResguardoAppService
+namespace ResguardoAppService
 {
     partial class Service1
     {
-        /// <summary> 
+        /// <summary>
         /// Required designer variable.
         /// </summary>
         private System.ComponentModel.IContainer components = null;
@@ -22,16 +22,17 @@
 
         #region Component Designer generated code
 
-        /// <summary> 
-        /// Required method for Designer support - do not modify 
+        /// <summary>
+        /// Required method for Designer support - do not modify
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            this.ServiceName = "Service1";
+            this.ServiceName = "ResguardoAppService";
         }
 
         #endregion
     }
 }
+

--- a/ResguardoAppService/Service1.cs
+++ b/ResguardoAppService/Service1.cs
@@ -1,30 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Diagnostics;
-using System.Linq;
-using System.ServiceProcess;
-using System.Text;
-using System.Threading.Tasks;
-
 using System.ServiceProcess;
 
 namespace ResguardoAppService
 {
-    public class Program
+    public partial class Service1 : ServiceBase
     {
-        public static void Main()
+        public Service1()
         {
-            ServiceBase.Run(new ResguardoService());
-        }
-    }
-
-    public class ResguardoService : ServiceBase
-    {
-        public ResguardoService()
-        {
-            this.ServiceName = "ResguardoAppService";
+            InitializeComponent();
         }
 
         protected override void OnStart(string[] args)
@@ -39,3 +21,4 @@ namespace ResguardoAppService
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- consolidate service entry point to run `Service1`
- replace extraneous `Program` and `ResguardoService` classes with a partial `Service1`
- set Windows service name in designer to `ResguardoAppService`

## Testing
- `dotnet build ResguardoApp/ResguardoApp.sln` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6894017bbf7c8329b41cbeca164e9a69