### PR TITLE
Use app directory for configuration

### DIFF
--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -18,7 +18,7 @@ namespace ResguardoApp
         {
             InitializeComponent();
             // Define configuration path
-            _configDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ResguardoApp");
+            _configDir = AppDomain.CurrentDomain.BaseDirectory;
             _configFile = Path.Combine(_configDir, "config.json");
 
             // Wire up events


### PR DESCRIPTION
## Summary
- store config in application base directory instead of LocalApplicationData

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_689426bb8bd8832996cbf48dd8d49808