### PR TITLE
Load configuration from executable directory

### DIFF
--- a/ResguardoApp/ResguardoService.cs
+++ b/ResguardoApp/ResguardoService.cs
@@ -15,8 +15,7 @@ namespace ResguardoApp
         public ResguardoService()
         {
             ServiceName = "ResguardoAppService";
-            var configDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ResguardoApp");
-            _configFile = Path.Combine(configDir, "config.json");
+            _configFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
         }
 
         protected override void OnStart(string[] args)


### PR DESCRIPTION
## Summary
- Read service configuration directly from the executable folder.

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_689426bd236c832982f38761bde3466f