### PR TITLE
Use application base directory for service configuration

### DIFF
--- a/ResguardoAppService/Service1.cs
+++ b/ResguardoAppService/Service1.cs
@@ -60,8 +60,7 @@ namespace ResguardoAppService
 
         private void LoadConfiguration()
         {
-            var configDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ResguardoApp");
-            var configFile = Path.Combine(configDir, "config.json");
+            var configFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
 
             if (!File.Exists(configFile))
             {


### PR DESCRIPTION
## Summary
- load configuration from service's base directory

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -c Release -p:EnableWindowsTargeting=true`
- `dotnet build ResguardoAppService/ResguardoAppService.csproj -c Release -p:EnableWindowsTargeting=true` *(fails: System.Text.Json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689426bfb40083299081322c983e903f