### PR TITLE
Enable applying pending configuration changes

### DIFF
--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -31,7 +31,7 @@ namespace ResguardoApp
             backupFoldersListBox = new ListBox();
             addFolderButton = new Button();
             removeFolderButton = new Button();
-            saveConfigButton = new Button();
+            applyConfigButton = new Button();
             portableDisksListBox = new ListBox();
             detectDrivesButton = new Button();
             label1 = new Label();
@@ -72,15 +72,16 @@ namespace ResguardoApp
             removeFolderButton.Text = "Quitar Carpeta";
             removeFolderButton.UseVisualStyleBackColor = true;
             // 
-            // saveConfigButton
-            // 
-            saveConfigButton.Location = new Point(537, 142);
-            saveConfigButton.Margin = new Padding(4, 5, 4, 5);
-            saveConfigButton.Name = "saveConfigButton";
-            saveConfigButton.Size = new Size(171, 38);
-            saveConfigButton.TabIndex = 4;
-            saveConfigButton.Text = "Guardar Config.";
-            saveConfigButton.UseVisualStyleBackColor = true;
+            // applyConfigButton
+            //
+            applyConfigButton.Enabled = false;
+            applyConfigButton.Location = new Point(537, 142);
+            applyConfigButton.Margin = new Padding(4, 5, 4, 5);
+            applyConfigButton.Name = "applyConfigButton";
+            applyConfigButton.Size = new Size(171, 38);
+            applyConfigButton.TabIndex = 4;
+            applyConfigButton.Text = "Aplicar Config.";
+            applyConfigButton.UseVisualStyleBackColor = true;
             // 
             // portableDisksListBox
             // 
@@ -175,7 +176,7 @@ namespace ResguardoApp
             Controls.Add(detectDrivesButton);
             Controls.Add(portableDisksListBox);
             Controls.Add(label2);
-            Controls.Add(saveConfigButton);
+            Controls.Add(applyConfigButton);
             Controls.Add(removeFolderButton);
             Controls.Add(addFolderButton);
             Controls.Add(backupFoldersListBox);
@@ -192,7 +193,7 @@ namespace ResguardoApp
         private System.Windows.Forms.ListBox backupFoldersListBox;
         private System.Windows.Forms.Button addFolderButton;
         private System.Windows.Forms.Button removeFolderButton;
-        private System.Windows.Forms.Button saveConfigButton;
+        private System.Windows.Forms.Button applyConfigButton;
         private System.Windows.Forms.ListBox portableDisksListBox;
         private System.Windows.Forms.Button detectDrivesButton;
         private System.Windows.Forms.Label label1;

--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -25,10 +25,11 @@ namespace ResguardoApp
             this.Load += MainForm_Load;
             addFolderButton.Click += AddFolderButton_Click;
             removeFolderButton.Click += RemoveFolderButton_Click;
-            saveConfigButton.Click += SaveConfigButton_Click;
+            applyConfigButton.Click += ApplyConfigButton_Click;
             detectDrivesButton.Click += DetectDrivesButton_Click;
             backupButton.Click += BackupButton_Click;
             installServiceButton.Click += InstallServiceButton_Click;
+            backupTimePicker.ValueChanged += BackupTimePicker_ValueChanged;
         }
 
         private void InstallServiceButton_Click(object? sender, EventArgs e)
@@ -94,6 +95,7 @@ namespace ResguardoApp
         }
 
         private AppConfig _currentConfig;
+        private bool configChanged;
 
         private void LoadConfiguration()
         {
@@ -148,6 +150,12 @@ namespace ResguardoApp
             }
         }
 
+        private void MarkConfigChanged()
+        {
+            configChanged = true;
+            applyConfigButton.Enabled = true;
+        }
+
 
         private void AddFolderButton_Click(object? sender, EventArgs e)
         {
@@ -162,6 +170,7 @@ namespace ResguardoApp
                         if (!backupFoldersListBox.Items.Contains(dialog.SelectedPath))
                         {
                             backupFoldersListBox.Items.Add(dialog.SelectedPath);
+                            MarkConfigChanged();
                         }
                         else
                         {
@@ -177,6 +186,7 @@ namespace ResguardoApp
             if (backupFoldersListBox.SelectedItem != null)
             {
                 backupFoldersListBox.Items.Remove(backupFoldersListBox.SelectedItem);
+                MarkConfigChanged();
             }
             else
             {
@@ -184,9 +194,16 @@ namespace ResguardoApp
             }
         }
 
-        private void SaveConfigButton_Click(object? sender, EventArgs e)
+        private void ApplyConfigButton_Click(object? sender, EventArgs e)
         {
             SaveConfiguration();
+            configChanged = false;
+            applyConfigButton.Enabled = false;
+        }
+
+        private void BackupTimePicker_ValueChanged(object? sender, EventArgs e)
+        {
+            MarkConfigChanged();
         }
 
         private void DetectDrivesButton_Click(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- replace save action with Apply Config button disabled until changes occur
- track configuration changes and enable apply button when folders or backup time are modified

## Testing
- `~/.dotnet/dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_6894b73f68ec83298d14f4df22d1ffce