### PR TITLE
Clean up duplicate service install handler

### DIFF
--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -168,7 +168,6 @@ namespace ResguardoApp
             installServiceButton.TabIndex = 10;
             installServiceButton.Text = "Instalar Servicio";
             installServiceButton.UseVisualStyleBackColor = true;
-            installServiceButton.Click += installServiceButton_Click_1;
             // 
             // label3
             // 

--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -274,9 +274,5 @@ namespace ResguardoApp
             MessageBox.Show("Respaldo completado.", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
-        private void installServiceButton_Click_1(object sender, EventArgs e)
-        {
-
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Remove duplicate click event wiring for the install service button
- Drop unused placeholder method so only `InstallServiceButton_Click` handles the button

## Testing
- `~/.dotnet/dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true -v:m`

------
https://chatgpt.com/codex/tasks/task_e_6894f274881c8329b15ba2c591f60ef3