### PR TITLE
Handle missing PNPDeviceID during disk validation

### DIFF
--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -263,11 +263,25 @@ namespace ResguardoApp
                 MessageBox.Show("Disco de respaldo registrado. Ahora puede realizar el respaldo.", "Información", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
-            else if (_currentConfig.DiscoRespaldo.VolumeSerialNumber != actual.VolumeSerialNumber ||
-                     _currentConfig.DiscoRespaldo.PNPDeviceID != actual.PNPDeviceID)
+            else
             {
-                MessageBox.Show("El disco seleccionado no coincide con el disco de respaldo registrado.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return;
+                bool serialMatch = string.Equals(
+                    _currentConfig.DiscoRespaldo.VolumeSerialNumber,
+                    actual.VolumeSerialNumber,
+                    StringComparison.OrdinalIgnoreCase);
+
+                bool pnpMatch = true;
+                if (!string.IsNullOrEmpty(_currentConfig.DiscoRespaldo.PNPDeviceID) &&
+                    !string.IsNullOrEmpty(actual.PNPDeviceID))
+                {
+                    pnpMatch = _currentConfig.DiscoRespaldo.PNPDeviceID == actual.PNPDeviceID;
+                }
+
+                if (!serialMatch || !pnpMatch)
+                {
+                    MessageBox.Show("El disco seleccionado no coincide con el disco de respaldo registrado.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
             }
 
             BackupService.PerformBackup(_currentConfig);


### PR DESCRIPTION
## Summary
- Capture removable drive PNPDeviceID information via `ManagementObjectSearcher`
- Compare disks using serial number and optional PNPDeviceID to tolerate missing identifiers

## Testing
- `dotnet build ResguardoApp/ResguardoApp.sln -p:EnableWindowsTargeting=true` *(fails: .NETFramework,Version=v4.7.2 reference assemblies not found)*
- `~/.dotnet/dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_6894f278f36483298130b5ed48aa5b04