### PR TITLE
Handle log file errors

### DIFF
--- a/ResguardoApp/ResguardoService.cs
+++ b/ResguardoApp/ResguardoService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.ServiceProcess;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Timers;
 
@@ -37,11 +38,32 @@ namespace ResguardoApp
             }
             catch (Exception ex)
             {
-                File.AppendAllText(_logFile,
-                    
-                    DateTime.Now + Environment.NewLine +
-                    ex.ToString() + Environment.NewLine +
-                    (ex.InnerException?.ToString() ?? "") + Environment.NewLine);
+                try
+                {
+                    var logDir = Path.GetDirectoryName(_logFile);
+                    if (!string.IsNullOrEmpty(logDir))
+                    {
+                        Directory.CreateDirectory(logDir);
+                    }
+
+                    File.AppendAllText(_logFile,
+
+                        DateTime.Now + Environment.NewLine +
+                        ex.ToString() + Environment.NewLine +
+                        (ex.InnerException?.ToString() ?? "") + Environment.NewLine);
+                }
+                catch (Exception logEx)
+                {
+                    try
+                    {
+                        EventLog.WriteEntry(ServiceName, $"Failed to write to log file: {logEx}", EventLogEntryType.Error);
+                    }
+                    catch
+                    {
+                        // Ignored: nothing else we can do if logging fails
+                    }
+                }
+
                 throw; // Dejá que el servicio falle igual para que el Event Viewer lo registre
             }
         }


### PR DESCRIPTION
## Summary
- Ensure log directory exists before logging
- Guard log writing with try/catch and send failures to EventLog

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68950db28d9883299bc082c5268c98fa