### PR TITLE
Log config load errors

### DIFF
--- a/ResguardoApp/ResguardoService.cs
+++ b/ResguardoApp/ResguardoService.cs
@@ -81,16 +81,25 @@ namespace ResguardoApp
         private void LoadConfiguration()
         {
             if (!File.Exists(_configFile))
+            {
+                File.AppendAllText(
+                    _logFile,
+                    DateTime.Now + " - Config file not found: " + _configFile + Environment.NewLine);
                 return;
+            }
 
             try
             {
                 var json = File.ReadAllText(_configFile);
                 _config = JsonSerializer.Deserialize<AppConfig>(json);
             }
-            catch
+            catch (Exception ex)
             {
-                // Log error
+                File.AppendAllText(
+                    _logFile,
+                    DateTime.Now + Environment.NewLine +
+                    ex.ToString() + Environment.NewLine +
+                    (ex.InnerException?.ToString() ?? "") + Environment.NewLine);
             }
         }
     }


### PR DESCRIPTION
## Summary
- log when `config.json` missing during service config load
- capture and record exceptions while parsing config file

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true` *(fails: The name '_lastBackupDate' does not exist in the current context)*

------
https://chatgpt.com/codex/tasks/task_e_68950db6a8e48329ba702052dbcc3a18