### PR TITLE
feat: allow forced backups on start or demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ ResguardoApp is a simple Windows Forms application for managing a list of folder
 -   **Automatic Loading**: The application automatically loads your saved configuration on startup.
 -   **Detect Portable Drives**: A dedicated feature to list all connected removable drives (e.g., USB flash drives, external hard drives).
 -   **Perform Backup**: Synchronize the selected folders to a chosen removable drive. The backup process is incremental, only copying new or modified files.
+-   **Force Backup**: Set `forceBackupOnStart` in `config.json` to `true` to run a backup when the service starts, or call the service's public `ForceBackup` method to trigger a backup on demand.
 
 ## Requirements
 
@@ -40,5 +41,10 @@ This project is a standard .NET WinForms application. You can build and run it u
 2.  **Open the `ResguardoApp.sln` file** in Visual Studio (or open the `ResguardoApp` folder).
 3.  **Set the startup project** to `ResguardoApp`.
 4.  **Press `F5`** to build and run the application in debug mode, or use the "Build" menu to create a release version.
+
+### Manual Backup Execution
+
+-   **Run on Service Start**: Edit `config.json` and set `forceBackupOnStart` to `true`. The service will execute a backup immediately after loading the configuration.
+-   **Run On Demand**: Use the `ForceBackup` method exposed by the service to perform a backup at any time without waiting for the scheduled time.
 
 **Important Note**: This is a Windows Forms application and can only be compiled and run on a Windows operating system.

--- a/ResguardoApp/AppConfig.cs
+++ b/ResguardoApp/AppConfig.cs
@@ -7,6 +7,7 @@ namespace ResguardoApp
         public List<string> BackupFolders { get; set; } = new List<string>();
         public DiscoRespaldoInfo DiscoRespaldo { get; set; }
         public string BackupTime { get; set; }
+        public bool ForceBackupOnStart { get; set; }
     }
 
     public class DiscoRespaldoInfo

--- a/ResguardoApp/ResguardoService.cs
+++ b/ResguardoApp/ResguardoService.cs
@@ -12,6 +12,7 @@ namespace ResguardoApp
         private AppConfig _config;
         private readonly string _configFile;
         private readonly string _logFile;
+        private DateTime? _lastBackupDate;
 
         public ResguardoService()
         {
@@ -33,6 +34,11 @@ namespace ResguardoApp
                 }
 
                 _timer.Interval = 60000; // 1 minuto
+                if (_config?.ForceBackupOnStart == true)
+                {
+                    BackupService.PerformBackup(_config);
+                    _lastBackupDate = DateTime.Now.Date;
+                }
                 _timer.Start();
             }
             catch (Exception ex)
@@ -76,6 +82,18 @@ namespace ResguardoApp
                 BackupService.PerformBackup(_config);
                 _lastBackupDate = now.Date;
             }
+        }
+
+        public void ForceBackup()
+        {
+            LoadConfiguration();
+            if (_config == null)
+            {
+                return;
+            }
+
+            BackupService.PerformBackup(_config);
+            _lastBackupDate = DateTime.Now.Date;
         }
 
         private void LoadConfiguration()

--- a/ResguardoAppService/Service1.cs
+++ b/ResguardoAppService/Service1.cs
@@ -34,6 +34,11 @@ namespace ResguardoAppService
             _timer.Elapsed += OnTimer;
 
             LoadConfiguration();
+            if (_config?.ForceBackupOnStart == true)
+            {
+                BackupService.PerformBackup(_config);
+                _lastBackupDate = DateTime.Now.Date;
+            }
 
             _timer.Start();
 
@@ -71,6 +76,18 @@ namespace ResguardoAppService
                 BackupService.PerformBackup(_config);
                 _lastBackupDate = now.Date;
             }
+        }
+
+        public void ForceBackup()
+        {
+            LoadConfiguration();
+            if (_config == null)
+            {
+                return;
+            }
+
+            BackupService.PerformBackup(_config);
+            _lastBackupDate = DateTime.Now.Date;
         }
 
         private void LoadConfiguration()

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "backupFolders": ["C:\\Path\\To\\Folder"],
+  "discoRespaldo": {
+    "letra": "E:\\",
+    "volumeSerialNumber": "",
+    "pnpDeviceID": ""
+  },
+  "backupTime": "02:00:00",
+  "forceBackupOnStart": false
+}


### PR DESCRIPTION
## Summary
- add `ForceBackupOnStart` flag to configuration
- support forcing backups on service start and via `ForceBackup`
- document manual and startup backup triggers

## Testing
- `dotnet build ResguardoAppService/ResguardoAppService.csproj` *(fails: .NETFramework,Version=v4.7.2 reference assemblies not found)*
- `dotnet build ResguardoApp/ResguardoApp.csproj` *(fails: set EnableWindowsTargeting on non-Windows OS)*

------
https://chatgpt.com/codex/tasks/task_e_68950dca1e1483298622fa94efe5b812