### PR TITLE
Clean up install service button handler

### DIFF
--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -186,10 +186,9 @@ namespace ResguardoApp
             installServiceButton.TabIndex = 10;
             installServiceButton.Text = "Instalar Servicio";
             installServiceButton.UseVisualStyleBackColor = true;
-            installServiceButton.Click += installServiceButton_Click_1;
-            // 
+            //
             // MainForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(727, 608);

--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -303,9 +303,5 @@ namespace ResguardoApp
             MessageBox.Show("Respaldo completado.", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
-        private void installServiceButton_Click_1(object sender, EventArgs e)
-        {
-
-        }
     }
 }


### PR DESCRIPTION
## Summary
- remove unused `installServiceButton_Click_1` handler and its designer wiring
- keep `InstallServiceButton_Click` as the button's sole click handler

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`
- `dotnet test ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68953afa7d4c8329a5e92ece92c13ad9