### PR TITLE
Remove unused Newtonsoft.Json dependency

### DIFF
--- a/ResguardoApp/BackupService.cs
+++ b/ResguardoApp/BackupService.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using Newtonsoft.Json;
 
 namespace ResguardoApp
 {

--- a/ResguardoApp/ResguardoApp.csproj
+++ b/ResguardoApp/ResguardoApp.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Management" Version="9.0.7" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.8" />


### PR DESCRIPTION
## Summary
- drop `using Newtonsoft.Json` from `BackupService`
- remove `Newtonsoft.Json` package reference from project file

## Testing
- `dotnet build ResguardoApp/ResguardoApp.csproj -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68953b03d5e08329a7a530824ec4c54c