### PR TITLE
chore: remove packages.config from service project

### DIFF
--- a/ResguardoAppService/packages.config
+++ b/ResguardoAppService/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
## Summary
- remove legacy `packages.config` from `ResguardoAppService`
- rely on `Newtonsoft.Json` via `<PackageReference>`

## Testing
- `/root/.dotnet/dotnet restore ResguardoAppService/ResguardoAppService.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68953b088034832986518cde234c5871