### PR TITLE
Handle missing backup config values

### DIFF
--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -116,9 +116,10 @@ namespace ResguardoApp
                         backupFoldersListBox.Items.Add(folder);
                 }
 
-                if (!string.IsNullOrEmpty(_currentConfig?.BackupTime))
+                var backupTimeString = _currentConfig?.BackupTime;
+                if (!string.IsNullOrEmpty(backupTimeString))
                 {
-                    if (DateTime.TryParse(_currentConfig.BackupTime, out var time))
+                    if (DateTime.TryParse(backupTimeString, out var time))
                     {
                         backupTimePicker.Value = time;
                     }
@@ -260,7 +261,13 @@ namespace ResguardoApp
                 return;
             }
 
-            var selectedDriveItem = portableDisksListBox.SelectedItem.ToString();
+            var selectedDriveItem = portableDisksListBox.SelectedItem?.ToString();
+            if (string.IsNullOrEmpty(selectedDriveItem))
+            {
+                MessageBox.Show("Seleccione un disco de respaldo válido.", "Advertencia", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
             var drive = DriveInfo.GetDrives()
                 .FirstOrDefault(d => selectedDriveItem.StartsWith(d.Name, StringComparison.OrdinalIgnoreCase));
 
@@ -273,7 +280,8 @@ namespace ResguardoApp
             var driveLetter = drive.Name.Replace("\\", "").ToUpper();
             var actual = DiscoUtil.ObtenerInfoDeDisco(driveLetter);
 
-            if (_currentConfig.DiscoRespaldo == null)
+            var discoRespaldo = _currentConfig.DiscoRespaldo;
+            if (discoRespaldo == null)
             {
                 _currentConfig.DiscoRespaldo = actual;
                 SaveConfiguration();
@@ -283,15 +291,15 @@ namespace ResguardoApp
             else
             {
                 bool serialMatch = string.Equals(
-                    _currentConfig.DiscoRespaldo.VolumeSerialNumber,
+                    discoRespaldo.VolumeSerialNumber,
                     actual.VolumeSerialNumber,
                     StringComparison.OrdinalIgnoreCase);
 
                 bool pnpMatch = true;
-                if (!string.IsNullOrEmpty(_currentConfig.DiscoRespaldo.PNPDeviceID) &&
+                if (!string.IsNullOrEmpty(discoRespaldo.PNPDeviceID) &&
                     !string.IsNullOrEmpty(actual.PNPDeviceID))
                 {
-                    pnpMatch = _currentConfig.DiscoRespaldo.PNPDeviceID == actual.PNPDeviceID;
+                    pnpMatch = discoRespaldo.PNPDeviceID == actual.PNPDeviceID;
                 }
 
                 if (!serialMatch || !pnpMatch)

--- a/ResguardoAppService/Service1.cs
+++ b/ResguardoAppService/Service1.cs
@@ -60,12 +60,14 @@ namespace ResguardoAppService
         private void OnTimer(object sender, ElapsedEventArgs e)
         {
             LoadConfiguration();
-            if (_config == null || string.IsNullOrEmpty(_config.BackupTime))
+            var config = _config;
+            var backupTimeString = config?.BackupTime;
+            if (string.IsNullOrEmpty(backupTimeString))
             {
                 return;
             }
 
-            if (!TimeSpan.TryParse(_config.BackupTime, out var backupTime))
+            if (!TimeSpan.TryParse(backupTimeString, out var backupTime))
             {
                 return;
             }
@@ -75,8 +77,11 @@ namespace ResguardoAppService
 
             if (now >= scheduled && (_lastBackupDate == null || _lastBackupDate.Value.Date < now.Date))
             {
-                BackupService.PerformBackup(_config);
-                _lastBackupDate = now.Date;
+                if (config != null)
+                {
+                    BackupService.PerformBackup(config);
+                    _lastBackupDate = now.Date;
+                }
             }
         }
 

--- a/SharedLib/AppConfig.cs
+++ b/SharedLib/AppConfig.cs
@@ -5,8 +5,8 @@ namespace SharedLib
     public class AppConfig
     {
         public List<string> BackupFolders { get; set; } = new List<string>();
-        public DiscoRespaldoInfo DiscoRespaldo { get; set; }
-        public string BackupTime { get; set; }
+        public DiscoRespaldoInfo? DiscoRespaldo { get; set; }
+        public string? BackupTime { get; set; }
         public bool ForceBackupOnStart { get; set; }
     }
 

--- a/SharedLib/BackupService.cs
+++ b/SharedLib/BackupService.cs
@@ -31,13 +31,14 @@ namespace SharedLib
                 return;
             }
 
-            if (config.DiscoRespaldo == null)
+            var discoRespaldo = config.DiscoRespaldo;
+            if (discoRespaldo == null)
             {
                 // Can't proceed without a registered backup disk.
                 return;
             }
 
-            var driveLetter = config.DiscoRespaldo.Letra.Replace("\\", "").ToUpper();
+            var driveLetter = discoRespaldo.Letra.Replace("\\", "").ToUpper();
             var destinationRoot = Path.Combine($"{driveLetter}\\", "ResguardoApp");
 
             foreach (var sourceFolder in sourceFolders)

--- a/SharedLib/ResguardoService.cs
+++ b/SharedLib/ResguardoService.cs
@@ -76,12 +76,14 @@ namespace SharedLib
         private void OnTimer(object sender, ElapsedEventArgs args)
         {
             LoadConfiguration();
-            if (_config == null || string.IsNullOrEmpty(_config.BackupTime))
+            var config = _config;
+            var backupTimeString = config?.BackupTime;
+            if (string.IsNullOrEmpty(backupTimeString))
             {
                 return;
             }
 
-            if (!TimeSpan.TryParse(_config.BackupTime, out var backupTime))
+            if (!TimeSpan.TryParse(backupTimeString, out var backupTime))
             {
                 return;
             }
@@ -93,7 +95,10 @@ namespace SharedLib
             {
                 try
                 {
-                    BackupService.PerformBackup(_config);
+                    if (config != null)
+                    {
+                        BackupService.PerformBackup(config);
+                    }
                     _lastBackupDate = now.Date;
                 }
                 catch (Exception ex)
@@ -119,7 +124,7 @@ namespace SharedLib
 
         private void LogSkip(DateTime now)
         {
-            var message = $"{now} - Resguardo omitido: no es la hora programada ({_config.BackupTime}).{Environment.NewLine}";
+            var message = $"{now} - Resguardo omitido: no es la hora programada ({_config?.BackupTime ?? "N/A"}).{Environment.NewLine}";
             if (message != _lastLogMessage || (now - _lastLogTime) > TimeSpan.FromMinutes(1))
             {
                 File.AppendAllText(_logFile, message);


### PR DESCRIPTION
## Summary
- Allow AppConfig's `DiscoRespaldo` and `BackupTime` to be null
- Add null checks when selecting backup disk
- Guard scheduled backup logic against missing times

## Testing
- `~/.dotnet/dotnet build ResguardoService.sln`
- `~/.dotnet/dotnet build ResguardoWinForms.sln`


------
https://chatgpt.com/codex/tasks/task_e_68956148d8408329bca65fcf4113531e