### PR TITLE
Add configurable backup day

### DIFF
--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -54,7 +54,9 @@ namespace ResguardoApp
             configPanel.Controls.Add(panel1);
             configPanel.Controls.Add(installServiceButton);
             configPanel.Controls.Add(portableDisksListBox);
+            configPanel.Controls.Add(backupDayComboBox);
             configPanel.Controls.Add(backupTimePicker);
+            configPanel.Controls.Add(label4);
             configPanel.Controls.Add(label3);
             configPanel.Controls.Add(applyConfigButton);
             configPanel.Controls.Add(removeFolderButton);
@@ -192,7 +194,27 @@ namespace ResguardoApp
             backupFoldersListBox.Name = "backupFoldersListBox";
             backupFoldersListBox.Size = new Size(600, 254);
             backupFoldersListBox.TabIndex = 2;
-            // 
+            //
+            // backupDayComboBox
+            //
+            backupDayComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            backupDayComboBox.FormattingEnabled = true;
+            backupDayComboBox.Items.AddRange(new object[] { "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo" });
+            backupDayComboBox.Location = new Point(658, 180);
+            backupDayComboBox.Name = "backupDayComboBox";
+            backupDayComboBox.Size = new Size(170, 33);
+            backupDayComboBox.TabIndex = 13;
+            //
+            // label4
+            //
+            label4.AutoSize = true;
+            label4.ForeColor = Color.Coral;
+            label4.Location = new Point(658, 150);
+            label4.Name = "label4";
+            label4.Size = new Size(151, 25);
+            label4.TabIndex = 14;
+            label4.Text = "Día de Respaldo:";
+            //
             // MainForm
             // 
             AutoScaleDimensions = new SizeF(10F, 25F);
@@ -224,5 +246,7 @@ namespace ResguardoApp
         private System.Windows.Forms.Panel configPanel;
         private Panel panel1;
         private ListBox backupFoldersListBox;
+        private ComboBox backupDayComboBox;
+        private Label label4;
     }
 }

--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -32,6 +32,7 @@ namespace ResguardoApp
             backupButton.Click += BackupButton_Click;
             installServiceButton.Click += InstallServiceButton_Click;
             backupTimePicker.ValueChanged += BackupTimePicker_ValueChanged;
+            backupDayComboBox.SelectedIndexChanged += BackupDayComboBox_SelectedIndexChanged;
         }
 
         private void InstallServiceButton_Click(object? sender, EventArgs e)
@@ -124,6 +125,9 @@ namespace ResguardoApp
                         backupTimePicker.Value = time;
                     }
                 }
+
+                var day = _currentConfig?.BackupDay ?? DayOfWeek.Monday;
+                backupDayComboBox.SelectedIndex = ((int)day + 6) % 7;
             }
             catch (Exception ex)
             {
@@ -138,6 +142,8 @@ namespace ResguardoApp
                 _currentConfig ??= new AppConfig();
                 _currentConfig.BackupFolders = backupFoldersListBox.Items.Cast<string>().ToList();
                 _currentConfig.BackupTime = backupTimePicker.Value.ToString("HH:mm");
+                var selectedIndex = backupDayComboBox.SelectedIndex < 0 ? 0 : backupDayComboBox.SelectedIndex;
+                _currentConfig.BackupDay = (DayOfWeek)((selectedIndex + 1) % 7);
 
                 Directory.CreateDirectory(_configDir);
                 var options = new JsonSerializerOptions { WriteIndented = true };
@@ -205,6 +211,11 @@ namespace ResguardoApp
         }
 
         private void BackupTimePicker_ValueChanged(object? sender, EventArgs e)
+        {
+            MarkConfigChanged();
+        }
+
+        private void BackupDayComboBox_SelectedIndexChanged(object? sender, EventArgs e)
         {
             MarkConfigChanged();
         }

--- a/ResguardoAppService/Service1.cs
+++ b/ResguardoAppService/Service1.cs
@@ -75,7 +75,8 @@ namespace ResguardoAppService
             var now = DateTime.Now;
             var scheduled = now.Date.Add(backupTime);
 
-            if (now >= scheduled && (_lastBackupDate == null || _lastBackupDate.Value.Date < now.Date))
+            if (now.DayOfWeek == config.BackupDay && now >= scheduled &&
+                (_lastBackupDate == null || _lastBackupDate.Value.Date < now.Date))
             {
                 if (config != null)
                 {

--- a/SharedLib/AppConfig.cs
+++ b/SharedLib/AppConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SharedLib
@@ -8,6 +9,7 @@ namespace SharedLib
         public DiscoRespaldoInfo? DiscoRespaldo { get; set; }
         public string? BackupTime { get; set; }
         public bool ForceBackupOnStart { get; set; }
+        public DayOfWeek BackupDay { get; set; } = DayOfWeek.Monday;
     }
 
     public class DiscoRespaldoInfo

--- a/SharedLib/ResguardoService.cs
+++ b/SharedLib/ResguardoService.cs
@@ -91,7 +91,9 @@ namespace SharedLib
             var now = DateTime.Now;
             var scheduled = now.Date.Add(backupTime);
 
-            if (now >= scheduled && (_lastBackupDate == null || _lastBackupDate.Value.Date < now.Date))
+            if (now.DayOfWeek == config.BackupDay &&
+                now >= scheduled &&
+                (_lastBackupDate == null || _lastBackupDate.Value.Date < now.Date))
             {
                 try
                 {

--- a/config.json
+++ b/config.json
@@ -6,5 +6,6 @@
     "pnpDeviceID": ""
   },
   "backupTime": "02:00:00",
-  "forceBackupOnStart": false
+  "forceBackupOnStart": false,
+  "backupDay": 1
 }


### PR DESCRIPTION
## Summary
- allow selecting backup day via new `BackupDay` config property and WinForms combo box
- persist selected backup day and respect it in service scheduling
- update sample `config.json` for migration

## Testing
- `dotnet build ResguardoWinForms.sln`
- `dotnet build ResguardoService.sln`


------
https://chatgpt.com/codex/tasks/task_e_6896cb865020832983ea40593e495acd