### PR TITLE
Configure backup time picker to show only time

### DIFF
--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -146,7 +146,9 @@ namespace ResguardoApp
             // backupTimePicker
             // 
             backupTimePicker.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
-            backupTimePicker.Format = DateTimePickerFormat.Time;
+            backupTimePicker.Format = DateTimePickerFormat.Custom;
+            backupTimePicker.CustomFormat = "HH:mm";
+            backupTimePicker.ShowUpDown = true;
             backupTimePicker.Location = new Point(658, 53);
             backupTimePicker.Margin = new Padding(4, 5, 4, 5);
             backupTimePicker.Name = "backupTimePicker";


### PR DESCRIPTION
## Summary
- show only hours and minutes in backup time picker by using a custom format and up/down control

## Testing
- `~/.dotnet/dotnet build ResguardoApp/ResguardoApp.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6896d3f4bc488329a90598f10a7cb55b