### PR TITLE
Track backup history for backups

### DIFF
--- a/SharedLib/BackupHistoryService.cs
+++ b/SharedLib/BackupHistoryService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace SharedLib
+{
+    public class BackupRecord
+    {
+        public DateTime Timestamp { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string? Details { get; set; }
+    }
+
+    public static class BackupHistoryService
+    {
+        private static readonly string _historyFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "backup_history.json");
+        private static readonly string _logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error_resguardo_service.txt");
+
+        private static void LogError(string message, Exception? ex = null)
+        {
+            try
+            {
+                File.AppendAllText(_logFile,
+                    DateTime.Now + " - " + message + Environment.NewLine +
+                    (ex?.ToString() ?? string.Empty) + Environment.NewLine);
+            }
+            catch
+            {
+                // Swallow any exceptions from logging to avoid recursive failures
+            }
+        }
+
+        public static void AddRecord(BackupRecord record)
+        {
+            try
+            {
+                List<BackupRecord> records = new();
+                if (File.Exists(_historyFile))
+                {
+                    var json = File.ReadAllText(_historyFile);
+                    if (!string.IsNullOrWhiteSpace(json))
+                    {
+                        var existing = JsonSerializer.Deserialize<List<BackupRecord>>(json);
+                        if (existing != null)
+                            records = existing;
+                    }
+                }
+                records.Add(record);
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                File.WriteAllText(_historyFile, JsonSerializer.Serialize(records, options));
+            }
+            catch (Exception ex)
+            {
+                LogError("Failed to add backup record", ex);
+            }
+        }
+
+        public static IEnumerable<BackupRecord> GetRecords()
+        {
+            try
+            {
+                if (!File.Exists(_historyFile))
+                    return Enumerable.Empty<BackupRecord>();
+
+                var json = File.ReadAllText(_historyFile);
+                var records = JsonSerializer.Deserialize<List<BackupRecord>>(json);
+                return records ?? Enumerable.Empty<BackupRecord>();
+            }
+            catch (Exception ex)
+            {
+                LogError("Failed to read backup history", ex);
+                return Enumerable.Empty<BackupRecord>();
+            }
+        }
+    }
+}

--- a/SharedLib/BackupService.cs
+++ b/SharedLib/BackupService.cs
@@ -41,12 +41,14 @@ namespace SharedLib
             var driveLetter = discoRespaldo.Letra.Replace("\\", "").ToUpper();
             var destinationRoot = Path.Combine($"{driveLetter}\\", "ResguardoApp");
 
+            var success = true;
             foreach (var sourceFolder in sourceFolders)
             {
                 var sourceDir = new DirectoryInfo(sourceFolder);
                 if (!sourceDir.Exists)
                 {
                     LogError($"Source folder not found: {sourceDir.FullName}");
+                    success = false;
                     continue;
                 }
 
@@ -61,8 +63,17 @@ namespace SharedLib
                 catch (Exception ex)
                 {
                     LogError($"Failed to synchronize directory {sourceDir.FullName}", ex);
+                    success = false;
                 }
             }
+
+            var record = new BackupRecord
+            {
+                Timestamp = DateTime.Now,
+                Status = success ? "Success" : "Error",
+                Details = success ? null : "Backup completed with errors. Check logs."
+            };
+            BackupHistoryService.AddRecord(record);
         }
 
         private static void SynchronizeDirectory(DirectoryInfo source, DirectoryInfo destination)


### PR DESCRIPTION
## Summary
- add BackupHistoryService to record backups in backup_history.json
- log each backup result from BackupService
- guard history writes with error logging

## Testing
- `~/.dotnet/dotnet build ResguardoService.sln`
- `~/.dotnet/dotnet build ResguardoWinForms.sln`


------
https://chatgpt.com/codex/tasks/task_e_6896dc378fd88329bf94ef4e2d63702e