### PR TITLE
Add history viewer to ResguardoApp

### DIFF
--- a/ResguardoApp/HistoryForm.Designer.cs
+++ b/ResguardoApp/HistoryForm.Designer.cs
@@ -1,0 +1,75 @@
+namespace ResguardoApp
+{
+    partial class HistoryForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.ListBox historyListBox;
+        private System.Windows.Forms.Button clearHistoryButton;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            historyListBox = new System.Windows.Forms.ListBox();
+            clearHistoryButton = new System.Windows.Forms.Button();
+            SuspendLayout();
+            // 
+            // historyListBox
+            // 
+            historyListBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            historyListBox.FormattingEnabled = true;
+            historyListBox.ItemHeight = 25;
+            historyListBox.Location = new System.Drawing.Point(12, 12);
+            historyListBox.Name = "historyListBox";
+            historyListBox.Size = new System.Drawing.Size(460, 354);
+            historyListBox.TabIndex = 0;
+            // 
+            // clearHistoryButton
+            // 
+            clearHistoryButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            clearHistoryButton.Location = new System.Drawing.Point(351, 372);
+            clearHistoryButton.Name = "clearHistoryButton";
+            clearHistoryButton.Size = new System.Drawing.Size(121, 38);
+            clearHistoryButton.TabIndex = 1;
+            clearHistoryButton.Text = "Limpiar";
+            clearHistoryButton.UseVisualStyleBackColor = true;
+            // 
+            // HistoryForm
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(484, 422);
+            Controls.Add(clearHistoryButton);
+            Controls.Add(historyListBox);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "HistoryForm";
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Historial de Resguardos";
+            ResumeLayout(false);
+        }
+
+        #endregion
+    }
+}

--- a/ResguardoApp/HistoryForm.cs
+++ b/ResguardoApp/HistoryForm.cs
@@ -1,0 +1,32 @@
+using SharedLib;
+using System;
+using System.Windows.Forms;
+
+namespace ResguardoApp
+{
+    public partial class HistoryForm : Form
+    {
+        public HistoryForm()
+        {
+            InitializeComponent();
+            LoadHistory();
+            clearHistoryButton.Click += ClearHistoryButton_Click;
+        }
+
+        private void LoadHistory()
+        {
+            var records = BackupHistoryService.GetRecords();
+            historyListBox.Items.Clear();
+            foreach (var record in records)
+            {
+                historyListBox.Items.Add(record);
+            }
+        }
+
+        private void ClearHistoryButton_Click(object? sender, EventArgs e)
+        {
+            BackupHistoryService.Clear();
+            LoadHistory();
+        }
+    }
+}

--- a/ResguardoApp/HistoryForm.resx
+++ b/ResguardoApp/HistoryForm.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -32,6 +32,7 @@ namespace ResguardoApp
             configPanel = new Panel();
             detectDrivesButton = new Button();
             backupButton = new Button();
+            showHistoryButton = new Button();
             panel1 = new Panel();
             backupFoldersListBox = new ListBox();
             installServiceButton = new Button();
@@ -54,6 +55,7 @@ namespace ResguardoApp
             configPanel.BackColor = SystemColors.ActiveCaptionText;
             configPanel.Controls.Add(detectDrivesButton);
             configPanel.Controls.Add(backupButton);
+            configPanel.Controls.Add(showHistoryButton);
             configPanel.Controls.Add(panel1);
             configPanel.Controls.Add(installServiceButton);
             configPanel.Controls.Add(portableDisksListBox);
@@ -91,9 +93,20 @@ namespace ResguardoApp
             backupButton.TabIndex = 8;
             backupButton.Text = "Realizar Resguardo Manual";
             backupButton.UseVisualStyleBackColor = true;
-            // 
+            //
+            // showHistoryButton
+            //
+            showHistoryButton.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+            showHistoryButton.Location = new Point(629, 440);
+            showHistoryButton.Margin = new Padding(4, 5, 4, 5);
+            showHistoryButton.Name = "showHistoryButton";
+            showHistoryButton.Size = new Size(226, 154);
+            showHistoryButton.TabIndex = 15;
+            showHistoryButton.Text = "Mostrar Historial";
+            showHistoryButton.UseVisualStyleBackColor = true;
+            //
             // panel1
-            // 
+            //
             panel1.BackColor = SystemColors.ControlDarkDark;
             panel1.Controls.Add(backupFoldersListBox);
             panel1.ForeColor = Color.Coral;
@@ -253,5 +266,6 @@ namespace ResguardoApp
         private ListBox backupFoldersListBox;
 
         private Label label4;
+        private System.Windows.Forms.Button showHistoryButton;
     }
 }

--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -30,6 +30,7 @@ namespace ResguardoApp
             applyConfigButton.Click += ApplyConfigButton_Click;
             detectDrivesButton.Click += DetectDrivesButton_Click;
             backupButton.Click += BackupButton_Click;
+            showHistoryButton.Click += ShowHistoryButton_Click;
             installServiceButton.Click += InstallServiceButton_Click;
             backupTimePicker.ValueChanged += BackupTimePicker_ValueChanged;
             backupDayComboBox.SelectedIndexChanged += BackupDayComboBox_SelectedIndexChanged;
@@ -322,6 +323,12 @@ namespace ResguardoApp
 
             BackupService.PerformBackup(_currentConfig);
             MessageBox.Show("Respaldo completado.", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private void ShowHistoryButton_Click(object? sender, EventArgs e)
+        {
+            using var historyForm = new HistoryForm();
+            historyForm.ShowDialog(this);
         }
 
     }

--- a/SharedLib/BackupHistoryService.cs
+++ b/SharedLib/BackupHistoryService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SharedLib
+{
+    public static class BackupHistoryService
+    {
+        private static readonly string HistoryFile;
+
+        static BackupHistoryService()
+        {
+            var logDir = Environment.GetEnvironmentVariable("RESGUARDO_LOG_PATH");
+            if (string.IsNullOrWhiteSpace(logDir))
+            {
+                logDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                    "ResguardoApp");
+            }
+
+            HistoryFile = Path.Combine(logDir, "backup_history.txt");
+        }
+
+        public static IList<string> GetRecords()
+        {
+            if (!File.Exists(HistoryFile))
+            {
+                return new List<string>();
+            }
+
+            return File.ReadAllLines(HistoryFile).ToList();
+        }
+
+        public static void Clear()
+        {
+            if (File.Exists(HistoryFile))
+            {
+                File.Delete(HistoryFile);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Mostrar Historial` button to main config panel
- Implement modal `HistoryForm` to display backup history with option to clear
- Add `BackupHistoryService` for retrieving and clearing stored history records

## Testing
- `~/.dotnet/dotnet build ResguardoWinForms.sln`

------
https://chatgpt.com/codex/tasks/task_e_6896dc3881f08329be8a2444e2a92f7a