### PR TITLE
Add backup history record model and UI formatting

### DIFF
--- a/ResguardoApp/HistoryForm.cs
+++ b/ResguardoApp/HistoryForm.cs
@@ -19,7 +19,7 @@ namespace ResguardoApp
             historyListBox.Items.Clear();
             foreach (var record in records)
             {
-                historyListBox.Items.Add(record);
+                historyListBox.Items.Add($"{record.Timestamp:u} | {record.Status} | {record.Details}");
             }
         }
 

--- a/SharedLib/BackupRecord.cs
+++ b/SharedLib/BackupRecord.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace SharedLib
+{
+    [Serializable]
+    public class BackupRecord
+    {
+        public DateTime Timestamp { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string? Details { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `BackupRecord` model for timestamped backup entries
- Persist backup history as JSON lines and deserialize in `BackupHistoryService`
- Format records for display in the history form

## Testing
- `dotnet build ResguardoWinForms.sln`
- `dotnet test ResguardoWinForms.sln`

------
https://chatgpt.com/codex/tasks/task_e_68977eaa05308329a6e00f5abe156977