### PR TITLE
Add restore service to copy backups back to original locations

### DIFF
--- a/SharedLib/RestoreService.cs
+++ b/SharedLib/RestoreService.cs
@@ -1,0 +1,227 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Management;
+
+namespace SharedLib
+{
+    public static class RestoreService
+    {
+        private static readonly string _logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error_resguardo_service.txt");
+
+        private static void LogError(string message, Exception? ex = null)
+        {
+            try
+            {
+                File.AppendAllText(_logFile,
+                    DateTime.Now + " - " + message + Environment.NewLine +
+                    (ex?.ToString() ?? string.Empty) + Environment.NewLine);
+            }
+            catch
+            {
+                // Ignore logging failures
+            }
+        }
+
+        public static void PerformRestore(AppConfig config)
+        {
+            var discoRespaldo = config.DiscoRespaldo;
+            if (discoRespaldo == null)
+            {
+                return; // No hay disco de respaldo registrado
+            }
+
+            var driveLetter = discoRespaldo.Letra.Replace("\\", "").ToUpper();
+            var actual = ObtenerInfoDeDisco(driveLetter);
+
+            bool serialMatch = string.Equals(
+                discoRespaldo.VolumeSerialNumber,
+                actual.VolumeSerialNumber,
+                StringComparison.OrdinalIgnoreCase);
+
+            bool pnpMatch = true;
+            if (!string.IsNullOrEmpty(discoRespaldo.PNPDeviceID) &&
+                !string.IsNullOrEmpty(actual.PNPDeviceID))
+            {
+                pnpMatch = string.Equals(
+                    discoRespaldo.PNPDeviceID,
+                    actual.PNPDeviceID,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (!serialMatch || !pnpMatch)
+            {
+                LogError("El disco seleccionado no coincide con el disco de respaldo registrado.");
+                return;
+            }
+
+            var backupRoot = Path.Combine($"{driveLetter}\\", "ResguardoApp");
+            var success = true;
+
+            foreach (var folder in config.BackupFolders)
+            {
+                var originalDir = new DirectoryInfo(folder);
+                var backupDir = new DirectoryInfo(Path.Combine(backupRoot, originalDir.Name));
+
+                if (!backupDir.Exists)
+                {
+                    LogError($"Backup folder not found: {backupDir.FullName}");
+                    success = false;
+                    continue;
+                }
+
+                if (!originalDir.Exists)
+                {
+                    try
+                    {
+                        originalDir.Create();
+                    }
+                    catch (Exception ex)
+                    {
+                        LogError($"Failed to create destination folder {originalDir.FullName}", ex);
+                        success = false;
+                        continue;
+                    }
+                }
+
+                try
+                {
+                    SynchronizeDirectory(backupDir, originalDir);
+                }
+                catch (Exception ex)
+                {
+                    LogError($"Failed to restore directory {originalDir.FullName}", ex);
+                    success = false;
+                }
+            }
+
+            var record = new BackupRecord
+            {
+                Timestamp = DateTime.Now,
+                Status = success ? "Restore Success" : "Restore Error",
+                Details = success ? null : "Restore completed with errors. Check logs."
+            };
+            BackupHistoryService.AddRecord(record);
+        }
+
+        private static void SynchronizeDirectory(DirectoryInfo source, DirectoryInfo destination)
+        {
+            foreach (var sourceFile in source.GetFiles())
+            {
+                var destFile = new FileInfo(Path.Combine(destination.FullName, sourceFile.Name));
+                if (!destFile.Exists || sourceFile.LastWriteTime > destFile.LastWriteTime)
+                {
+                    try
+                    {
+                        sourceFile.CopyTo(destFile.FullName, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogError($"Failed to copy file {sourceFile.FullName}", ex);
+                    }
+                }
+            }
+
+            foreach (var sourceSubDir in source.GetDirectories())
+            {
+                var destSubDir = new DirectoryInfo(Path.Combine(destination.FullName, sourceSubDir.Name));
+                if (!destSubDir.Exists)
+                {
+                    destSubDir.Create();
+                }
+
+                try
+                {
+                    SynchronizeDirectory(sourceSubDir, destSubDir);
+                }
+                catch (Exception ex)
+                {
+                    LogError($"Failed to synchronize directory {sourceSubDir.FullName}", ex);
+                }
+            }
+        }
+
+        private static DiscoRespaldoInfo ObtenerInfoDeDisco(string letra)
+        {
+            var letraNormalizada = letra.ToUpper().Replace(":", string.Empty).Replace("\\", string.Empty);
+            var info = new DiscoRespaldoInfo { Letra = letraNormalizada + ":" };
+
+            try
+            {
+                string rootPath = letraNormalizada + @":\\";
+                bool success = GetVolumeInformation(
+                    rootPath,
+                    null,
+                    0,
+                    out uint serialNumber,
+                    out _, out _,
+                    null,
+                    0
+                );
+
+                if (success)
+                {
+                    info.VolumeSerialNumber = serialNumber.ToString("X");
+                }
+                else
+                {
+                    info.VolumeSerialNumber = "ERROR";
+                }
+            }
+            catch (Exception)
+            {
+                info.VolumeSerialNumber = "EXCEPTION";
+            }
+
+            try
+            {
+                using var query = new ManagementObjectSearcher("SELECT * FROM Win32_DiskDrive");
+                using ManagementObjectCollection drives = query.Get();
+                foreach (ManagementObject drive in drives)
+                {
+                    using (drive)
+                    {
+                        using ManagementObjectCollection partitions = drive.GetRelated("Win32_DiskPartition");
+                        foreach (ManagementObject partition in partitions)
+                        {
+                            using (partition)
+                            {
+                                using ManagementObjectCollection logicalDisks = partition.GetRelated("Win32_LogicalDisk");
+                                foreach (ManagementObject ld in logicalDisks)
+                                {
+                                    using (ld)
+                                    {
+                                        if (string.Equals(ld["DeviceID"]?.ToString(), $"{letraNormalizada}:", StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            info.PNPDeviceID = drive["PNPDeviceID"]?.ToString();
+                                            return info;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // ignore errors
+            }
+
+            return info;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool GetVolumeInformation(
+            string lpRootPathName,
+            System.Text.StringBuilder? lpVolumeNameBuffer,
+            int nVolumeNameSize,
+            out uint lpVolumeSerialNumber,
+            out uint lpMaximumComponentLength,
+            out uint lpFileSystemFlags,
+            System.Text.StringBuilder? lpFileSystemNameBuffer,
+            int nFileSystemNameSize);
+    }
+}
+

--- a/SharedLib/SharedLib.csproj
+++ b/SharedLib/SharedLib.csproj
@@ -4,10 +4,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.8" />
+    <PackageReference Include="System.Management" Version="9.0.7" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- implement `RestoreService` to restore folders from the backup disk back to their original locations
- validate the backup disk by serial and PNP identifier before copying
- log restore actions and record history entries

## Testing
- `dotnet build ResguardoService.sln`
- `dotnet build ResguardoWinForms.sln`

------
https://chatgpt.com/codex/tasks/task_e_6898363f48908329a5f6f34c4ff9fc4e