### PR TITLE
Add restore functionality to main form

### DIFF
--- a/ResguardoApp/MainForm.Designer.cs
+++ b/ResguardoApp/MainForm.Designer.cs
@@ -55,6 +55,7 @@ namespace ResguardoApp
             configPanel.BackColor = SystemColors.ActiveCaptionText;
             configPanel.Controls.Add(detectDrivesButton);
             configPanel.Controls.Add(backupButton);
+            configPanel.Controls.Add(restoreButton);
             configPanel.Controls.Add(showHistoryButton);
             configPanel.Controls.Add(panel1);
             configPanel.Controls.Add(installServiceButton);
@@ -94,14 +95,25 @@ namespace ResguardoApp
             backupButton.Text = "Realizar Resguardo Manual";
             backupButton.UseVisualStyleBackColor = true;
             //
+            // restoreButton
+            //
+            restoreButton.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+            restoreButton.Location = new Point(629, 440);
+            restoreButton.Margin = new Padding(4, 5, 4, 5);
+            restoreButton.Name = "restoreButton";
+            restoreButton.Size = new Size(226, 154);
+            restoreButton.TabIndex = 15;
+            restoreButton.Text = "Restaurar Resguardo";
+            restoreButton.UseVisualStyleBackColor = true;
+            //
             // showHistoryButton
             //
             showHistoryButton.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-            showHistoryButton.Location = new Point(629, 440);
+            showHistoryButton.Location = new Point(629, 314);
             showHistoryButton.Margin = new Padding(4, 5, 4, 5);
             showHistoryButton.Name = "showHistoryButton";
             showHistoryButton.Size = new Size(226, 154);
-            showHistoryButton.TabIndex = 15;
+            showHistoryButton.TabIndex = 16;
             showHistoryButton.Text = "Mostrar Historial";
             showHistoryButton.UseVisualStyleBackColor = true;
             //
@@ -266,6 +278,7 @@ namespace ResguardoApp
         private ListBox backupFoldersListBox;
 
         private Label label4;
+        private System.Windows.Forms.Button restoreButton;
         private System.Windows.Forms.Button showHistoryButton;
     }
 }

--- a/SharedLib/RestoreService.cs
+++ b/SharedLib/RestoreService.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace SharedLib
+{
+    public static class RestoreService
+    {
+        private static readonly string _logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error_resguardo_service.txt");
+
+        private static void LogError(string message, Exception? ex = null)
+        {
+            try
+            {
+                File.AppendAllText(_logFile,
+                    DateTime.Now + " - " + message + Environment.NewLine +
+                    (ex?.ToString() ?? string.Empty) + Environment.NewLine);
+            }
+            catch
+            {
+                // Ignorar errores de log para evitar fallos recursivos
+            }
+        }
+
+        public static void PerformRestore(AppConfig config)
+        {
+            var sourceFolders = config.BackupFolders;
+            if (!sourceFolders.Any())
+            {
+                return;
+            }
+
+            var discoRespaldo = config.DiscoRespaldo;
+            if (discoRespaldo == null)
+            {
+                return;
+            }
+
+            var driveLetter = discoRespaldo.Letra.Replace("\\", "").ToUpper();
+            var backupRoot = Path.Combine($"{driveLetter}\\", "ResguardoApp");
+
+            foreach (var originalFolder in sourceFolders)
+            {
+                var folderName = new DirectoryInfo(originalFolder).Name;
+                var sourceDir = new DirectoryInfo(Path.Combine(backupRoot, folderName));
+                if (!sourceDir.Exists)
+                {
+                    LogError($"Backup folder not found: {sourceDir.FullName}");
+                    continue;
+                }
+
+                var destDir = new DirectoryInfo(originalFolder);
+                if (!destDir.Exists)
+                    destDir.Create();
+
+                try
+                {
+                    SynchronizeDirectory(sourceDir, destDir);
+                }
+                catch (Exception ex)
+                {
+                    LogError($"Failed to restore directory {originalFolder}", ex);
+                }
+            }
+        }
+
+        private static void SynchronizeDirectory(DirectoryInfo source, DirectoryInfo destination)
+        {
+            foreach (var sourceFile in source.GetFiles())
+            {
+                var destinationFile = new FileInfo(Path.Combine(destination.FullName, sourceFile.Name));
+                if (!destinationFile.Exists || sourceFile.LastWriteTime > destinationFile.LastWriteTime)
+                {
+                    try
+                    {
+                        sourceFile.CopyTo(destinationFile.FullName, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogError($"Failed to copy file {sourceFile.FullName}", ex);
+                    }
+                }
+            }
+
+            foreach (var sourceSubDir in source.GetDirectories())
+            {
+                var destinationSubDir = new DirectoryInfo(Path.Combine(destination.FullName, sourceSubDir.Name));
+                if (!destinationSubDir.Exists)
+                {
+                    destinationSubDir.Create();
+                }
+                try
+                {
+                    SynchronizeDirectory(sourceSubDir, destinationSubDir);
+                }
+                catch (Exception ex)
+                {
+                    LogError($"Failed to synchronize directory {sourceSubDir.FullName}", ex);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Restore button and reposition history button
- wire restore button to new restore workflow
- introduce RestoreService to copy data back from backup disk

## Testing
- `~/.dotnet/dotnet build ResguardoWinForms.sln`

------
https://chatgpt.com/codex/tasks/task_e_6898363fecbc8329a1e325610bc5eb02