### PR TITLE
Adjust service button text based on installation state

### DIFF
--- a/ResguardoApp/MainForm.cs
+++ b/ResguardoApp/MainForm.cs
@@ -58,6 +58,8 @@ namespace ResguardoApp
                     ExecuteCommand($"sc create {serviceName} binPath= \"{exePath}\" start= auto");
                     MessageBox.Show("Servicio instalado exitosamente.", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
+
+                installServiceButton.Text = IsServiceInstalled(serviceName) ? "Desinstalar Servicio" : "Instalar Servicio";
             }
             catch (Exception ex)
             {
@@ -137,6 +139,8 @@ namespace ResguardoApp
                     }
                 }
             }
+
+            installServiceButton.Text = IsServiceInstalled("ResguardoAppService") ? "Desinstalar Servicio" : "Instalar Servicio";
         }
 
         private List<DriveInfo> PopulateRemovableDrives()


### PR DESCRIPTION
## Summary
- Update service install button text on load depending on whether the service exists
- Refresh button text after install/uninstall actions complete

## Testing
- `/root/.dotnet/dotnet build ResguardoWinForms.sln`
- `/root/.dotnet/dotnet build ResguardoWinForms.sln --no-restore` *(fails: Unable to find fallback package folder)*

------
https://chatgpt.com/codex/tasks/task_e_68992a00ea8c8329adb522ff292f3f98